### PR TITLE
[Feature/slack exception-1] BusinessException 발생시 슬랙 메세지 전달

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,11 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-webflux"
     implementation "org.springframework.boot:spring-boot-starter-data-redis"
+    implementation 'org.springframework.boot:spring-boot-starter-parent'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // metadata config
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     // database
     runtimeOnly "mysql:mysql-connector-java"

--- a/src/main/java/com/service/core/common/properties/SlackProperties.java
+++ b/src/main/java/com/service/core/common/properties/SlackProperties.java
@@ -1,0 +1,10 @@
+package com.service.core.common.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "logging.slack.uri")
+public record SlackProperties(String slackError, String slackGlassBottle
+        , String slackJoinMember, String slackServerHealth) {
+}

--- a/src/main/java/com/service/core/common/resttemplate/RestTemplateService.java
+++ b/src/main/java/com/service/core/common/resttemplate/RestTemplateService.java
@@ -1,5 +1,7 @@
 package com.service.core.common.resttemplate;
 
+import com.service.core.common.properties.SlackProperties;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -8,27 +10,38 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Service
+@RequiredArgsConstructor
 public class RestTemplateService {
 
+    private final SlackProperties slackProperties;
+
     public ResponseEntity<String> postToSlack(String uri, String sender, Object data) {
+        HttpEntity<Map<String, Object>> entity = createPostSetting(sender, data, ":love_letter:");
+
+        ResponseEntity<String> response = new RestTemplate().exchange(uri, HttpMethod.POST, entity, String.class);
+
+        return response;
+    }
+
+    public void postExceptionToSlack(String message) {
+        HttpEntity<Map<String, Object>> entity = createPostSetting("EXCEPTION-ALARM", message, ":hot_face:");
+
+        new RestTemplate().exchange(slackProperties.slackError(), HttpMethod.POST, entity, String.class);
+    }
+
+    public String getToUri(String uri) {
+        return new RestTemplate().getForObject(uri, String.class);
+    }
+
+    private HttpEntity<Map<String, Object>> createPostSetting(String sender, Object data, String icon) {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
 
         Map<String, Object> request = new HashMap<>();
         request.put("username", sender);
         request.put("text", data);
-        request.put("icon_emoji", ":love_letter:");
+        request.put("icon_emoji", icon);
 
-        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request, httpHeaders);
-
-        RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.POST, entity, String.class);
-
-        return response;
-    }
-
-    public String getToUri(String uri) {
-        RestTemplate restTemplate = new RestTemplate();
-        return restTemplate.getForObject(uri, String.class);
+        return new HttpEntity<>(request, httpHeaders);
     }
 }

--- a/src/main/java/com/service/core/config/properties/SlackPropertiesConfig.java
+++ b/src/main/java/com/service/core/config/properties/SlackPropertiesConfig.java
@@ -1,0 +1,9 @@
+package com.service.core.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan("com.service.core.common.properties")
+public class SlackPropertiesConfig {
+}

--- a/src/main/java/com/service/core/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/service/core/error/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.service.core.error;
 
 
+import com.service.core.common.resttemplate.RestTemplateService;
 import com.service.core.error.dto.ErrorMessage;
 import com.service.core.error.dto.ErrorResponseDto;
 import com.service.core.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -12,11 +14,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private final RestTemplateService restTemplateService;
+
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponseDto> handleBusinessException(BusinessException e) {
         var errorMessage = e.getErrorMessage();
 
+        restTemplateService.postExceptionToSlack(e.getMessage());
         log.error("[ERROR] BusinessException -> {}", errorMessage.getMessage());
 
         return ErrorResponseDto.of(errorMessage);

--- a/src/main/java/com/service/core/slack/application/SlackSchedulerService.java
+++ b/src/main/java/com/service/core/slack/application/SlackSchedulerService.java
@@ -1,13 +1,12 @@
-package com.service.core.slack.presentation;
+package com.service.core.slack.application;
 
+import com.service.core.common.properties.SlackProperties;
 import com.service.core.common.resttemplate.RestTemplateService;
 import com.service.core.member.application.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-
 
 @Service
 @Slf4j
@@ -17,14 +16,7 @@ public class SlackSchedulerService {
 
     private final RestTemplateService restTemplateService;
 
-    @Value("${logging.slack.uri.slack-glass-bottle}")
-    private String letterUri;
-
-    @Value("${logging.slack.uri.slack-join-member}")
-    private String memberUri;
-
-    @Value("${logging.slack.uri.slack-server-health}")
-    private String serverHealthUri;
+    private final SlackProperties slackProperties;
 
 
 //    @Scheduled(cron = "0 0 8 * * *")
@@ -35,14 +27,14 @@ public class SlackSchedulerService {
 
     @Scheduled(cron = "0 0 8 * * *")
     private void schedulerYesterdayJoinMember() {
-        var response = restTemplateService.postToSlack(memberUri, "Slack Message", memberService.getYesterdayJoinUsers());
+        var response = restTemplateService.postToSlack(slackProperties.slackJoinMember(), "Slack Message", memberService.getYesterdayJoinUsers());
         log.info(String.valueOf(response));
     }
 
     @Scheduled(cron = "0 0 */1 * * *")
     private void schedulerServerStateCheck() {
         var health = restTemplateService.getToUri("http://localhost:8080/actuator/health");
-        var response =restTemplateService.postToSlack(serverHealthUri, "Server Health", health);
+        var response =restTemplateService.postToSlack(slackProperties.slackServerHealth(), "Server Health", health);
         log.info(String.valueOf(response));
     }
 }


### PR DESCRIPTION
### 💡 개요
- BusinessException도 슬랙 메세지로 모니터링
- Value 어노테이션이 아닌 ConfigurationProperties를 이용하여 yml 값 받아오기
- resolved #51 

### 📑 작업 사항
- GlobalExceptionHandler 클래스의 handleBusinessException 메소드에서 exception message Slack 전송
- yml값을 Value 어노테이션이 아닌 SlackProperties 클래스에서 값을 받아옴
- ConfigurationProperties 기능 구현을 위한 build.gralde 추가


### ✒️ 코드 리뷰 요청 사항
- 코드 구현 방법이나 방향이 올바른지
- 더 나은 방안이 있는지


### ✔️ 코드 리뷰 반영 사항
-